### PR TITLE
Fixed wrong documentation about Security->Users menu access

### DIFF
--- a/docs/Administering/Managing-Users-and-Roles/privileges-and-permissions-d7350c6.md
+++ b/docs/Administering/Managing-Users-and-Roles/privileges-and-permissions-d7350c6.md
@@ -501,7 +501,7 @@ Allows access to the *Roles* app.
 
 The *Read* permission lets you see a list of users in a dialog; for example, when choosing which users to share a story with, or when choosing users to add to a team.
 
-To see the user list in *Security* \> *Users*, you need the *Read* permission, plus one of the *Create*, *Update*, or *Delete* permissions. If you have only the *Read* permission, you won't be able to view the user list.
+To see the user list in *Security* \> *Users*, you need *Read*, *Create*, *Update*, and *Delete* permissions. Pleas note that the *Create*, *Update*, and *Delete* permissions are only assigned if your role is derived from the *DW Administrator* role and cannot be set manually in the role editor. If you have only the *Read* permission, you won't be able to view the user list.
 
 Set the *Manage* permission to permit assigning users to roles, and approving role assignment requests from users.
 


### PR DESCRIPTION
My is Mario Kabadiyski. I am development architect in the Datasphere Cross-Architecture team and would like to fix an inconsistency in this document that we recently found due to a customer incident.

The documentation about accessing the Security->Users menu in the Datasphere security application falsely claimed that this menu can be accessed by a user having just the USER.read and one of the permissions USER.create, USER.update or USER.delete permissions. This has never been implemented like this and also doesn't work because all four permissions are required to access this menu. However, since only USER.read and USER.manage can be manually set in the role editor, in fact, only user roles that have been derived from the DW Administrator role can have all 4 USER permissions set and hence be able to access the Security->Users menu and screen. The current change corrects the documentation to reflect the real implementation that has been in place for more than 3 years now.