### PR TITLE
Update create-users-and-assign-them-to-roles-via-the-scim-2-0-api-1ca…

### DIFF
--- a/docs/Administering/Managing-Users-and-Roles/create-users-and-assign-them-to-roles-via-the-scim-2-0-api-1ca8c4a.md
+++ b/docs/Administering/Managing-Users-and-Roles/create-users-and-assign-them-to-roles-via-the-scim-2-0-api-1ca8c4a.md
@@ -147,8 +147,10 @@ password
 Syntax of GET request:
 
 ```
-https://<tenant-url>/oauth/token?grant_type=client_credentials
+https://<token-url>/oauth/token?grant_type=client_credentials
 ```
+> ### Note:  
+> The token URL is listed in the System > Administration menu.
 
 The response body returns the access token, which you'll then use as the bearer token to obtain the csrf token.
 


### PR DESCRIPTION
…8c4a.md

The current help version has the wrong URL. The <tenant URL>  (e.g. tenant.eu10.hcs.cloud.sap) has a different domain than the <authorization URL> (e.g. tenant.authentication.eu10.hana.ondemand.com) which is actually required for SCIM API.  Without this correction it is not possible to use the SCIM API.

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

